### PR TITLE
Fixed terminator and added ring event for transfer

### DIFF
--- a/tropo.py
+++ b/tropo.py
@@ -426,7 +426,7 @@ class Transfer(TropoAction):
         "timeout": Float } }
     """
     action = 'transfer'
-    options_array = ['answerOnMedia', 'choices', 'from', 'name', 'required', 'terminator', 'allowSignals']
+    options_array = ['answerOnMedia', 'choices', 'from', 'name', 'on', 'required', 'allowSignals']
 
     def __init__(self, to, **options):
         self._dict = {'to': to}
@@ -435,7 +435,7 @@ class Transfer(TropoAction):
                 if (opt == 'from'):
                     self._dict['from'] = options['from']
                 elif(opt == 'choices'):
-                    self._dict['choices'] = {'value' : options['choices']}
+                    self._dict['choices'] = options['choices']
                 else:
                     self._dict[opt] = options[opt]
 


### PR DESCRIPTION
Terminator is a parameter of choices, so modified choices to omit "value" and removed independent terminator parameter (which did not work).  Added 'on' to the list of parameters.  Example using the modifications:

t = Tropo()

t.transfer(["+14075551212","18005551212"], choices = {"terminator":"#"}, on = {"event":"ring", "say":{"value":"http://www.phono.com/audio/holdmusic.mp3"}})
