### PR TITLE
Updates to the webAPI Python library

### DIFF
--- a/tropo.py
+++ b/tropo.py
@@ -472,7 +472,28 @@ class Transfer(TropoAction):
                     self._dict['choices'] = options['choices']
                 else:
                     self._dict[opt] = options[opt]
+                    
+class Wait(TropoAction):
+      """
+      Class representing the "wait" Tropo action. Builds a "wait" JSON object.
+      Class constructor arg: milliseconds, an Integer
+      Class constructor options: allowSignals
+      Convenience function: Tropo.wait()
 
+      (See https://www.tropo.com/docs/webapi/wait.htm)
+      { "wait": {
+          "milliseconds": Integer,#Required
+          "allowSignals": String or Array
+      """
+      
+      action = 'wait'
+      options_array = ['allowSignals']
+
+      def __init__(self, milliseconds, **options):
+          self._dict = {'milliseconds': milliseconds}
+          for opt in self.options_array:
+              if opt in options:
+                self._dict[opt] = options[opt]
 
 class Result(object):
     """
@@ -717,7 +738,16 @@ class Tropo(object):
         See https://www.tropo.com/docs/webapi/transfer.htm
         """
         self._steps.append(Transfer(to, **options).obj)
-
+        
+    def wait(self, milliseconds, **options):
+      """
+      Allows the thread to sleep for a given amount of time in milliseconds
+      Argument: milliseconds is an Integer
+      Argument: **options is a set of optional keyword arguments.
+      See https://www.tropo.com/docs/webapi/wait.htm
+      """
+      self._steps.append(Wait(milliseconds, **options).obj)
+      
     def RenderJson(self, pretty=False):
         """
         Render a Tropo object into a Json string.


### PR DESCRIPTION
Things that were updated shown below:

1) Ask method
-Added interdigitTimeout
-Added allowSignals

2)Call method
-Added allowSignals

3)Conference method
-Added interdigitTimeout
-Added allowSignals

4)StartRecording method
-Added transcriptionID
-Added transcriptionEmailFormat
-Added transcriptionOutURI

Added a new method Wait
Params:
-milliseconds
-allowSiganls
