### PR TITLE
Make compatible with Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ as "say". In some cases, you'll want to build a class object directly such as in
 
 ## Note on Python versions
 
-This module is for python 2.x and requires python 2.5 or higher.  
-There is a separate version available for python 3.x at:
-
-      http://github.com/tropo/python-webapi/tree/python3
+This module is for Python 3 and 2.5 or higher.  
 
 ## License
 

--- a/samples/gh-12-test_voice.py
+++ b/samples/gh-12-test_voice.py
@@ -35,7 +35,7 @@ def index(request):
 
 
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 

--- a/samples/gh-14.test_call.py
+++ b/samples/gh-14.test_call.py
@@ -23,7 +23,7 @@ def index(request):
     t.call(to='tel:+' + TO_NUMBER, _from='tel:+' + FROM_NUMBER)
     t.say('This is your mother. Did you brush your teeth today?')
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 

--- a/samples/gh-14.test_message.py
+++ b/samples/gh-14.test_message.py
@@ -20,9 +20,9 @@ FROM_NUMBER = '1yyyyyyyyyy'
 def index(request):
         t = Tropo()
         t.message("Hello World", TO_NUMBER, channel='VOICE', _from='tel:+' + FROM_NUMBER)
-	json = t.RenderJson()
-	print json
-	return json
+        json = t.RenderJson()
+        print(json)
+        return json
 #retest
 
 

--- a/samples/gh-14.test_say.py
+++ b/samples/gh-14.test_say.py
@@ -17,7 +17,7 @@ def index(request):
     t = Tropo()
     t.say('12345', _as='DIGITS', voice='dave')
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 

--- a/samples/gh-14.test_transfer.py
+++ b/samples/gh-14.test_transfer.py
@@ -25,7 +25,7 @@ def index(request):
     t.transfer(TO_NUMBER, _from="tel:+" + FROM_NUMBER)
     t.say("Hi. I am a robot")
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 

--- a/samples/gh-14_test.py
+++ b/samples/gh-14_test.py
@@ -14,7 +14,7 @@ def index(request):
     t = Tropo()
     t.say('12345', _as='DIGITS', voice='allison')
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 run_itty()

--- a/samples/gh-17.test.py
+++ b/samples/gh-17.test.py
@@ -11,7 +11,7 @@ def index(request):
 	t.on(event = "continue", next ="/continue")
 	t.on(event = "incomplete", next ="/incomplete")
 	json = t.RenderJson()
-	print json
+	print(json)
 	return json
 
 @post("/continue")
@@ -29,7 +29,7 @@ def index(request):
 		t.say("What are you waiting for?")
 
 	json = t.RenderJson()
-	print json
+	print(json)
 	return json
 
 @post("/incomplete")
@@ -37,7 +37,7 @@ def index(request):
 	t = Tropo()
 	t.say("Sorry, that wasn't on of the options.")
 	json = t.RenderJson()
-	print json
+	print(json)
 	return json
 
 run_itty()

--- a/samples/gh-20-test_ask.py
+++ b/samples/gh-20-test_ask.py
@@ -19,16 +19,16 @@ def index(request):
 
 	t.on(event = "continue", next ="/continue")
 
-        json = t.RenderJson()
+	json = t.RenderJson()
 
-        print json
+	print(json)
 	return json
 
 @post("/continue")
 def index(request):
 
 	r = Result(request.body)        
-        print "Result : %s" % r
+	print("Result : %s" % r)
 
 	t = Tropo()
 
@@ -37,8 +37,8 @@ def index(request):
 
 	t.say("You said " + answer + ", which is a " + value)
 
-        json = t.RenderJson()
-        print json
+	json = t.RenderJson()
+	print(json)
 	return json
 
 run_itty()

--- a/samples/gh-21.choices.py
+++ b/samples/gh-21.choices.py
@@ -20,21 +20,21 @@ def index(request):
 
 	t = Tropo()
 
-        choices = Choices("[4-5 DIGITS]", mode="dtmf", terminator = "#")
+	choices = Choices("[4-5 DIGITS]", mode="dtmf", terminator = "#")
 	t.ask(choices, timeout=15, name="digit", say = "What's your four or five digit pin? Press pound when finished.")
 
 	t.on(event = "continue", next ="/continue")
 
-        json = t.RenderJson()
+	json = t.RenderJson()
 
-        print json
+	print(json)
 	return json
 
 @post("/continue")
 def index(request):
 
 	r = Result(request.body)        
-        print "Result : %s" % r
+        print("Result : %s" % r)
 #        dump(r)
 	t = Tropo()
 
@@ -43,8 +43,8 @@ def index(request):
 	t.say("You said ")
 	t.say (answer, _as="DIGITS")
 
-        json = t.RenderJson()
-        print json
+	json = t.RenderJson()
+	print(json)
 	return json
 
 run_itty()

--- a/samples/gh-22.transfer.py
+++ b/samples/gh-22.transfer.py
@@ -30,7 +30,7 @@ def index(request):
   t.transfer(TO_NUMBER, headers={"x-callername":"Kevin Bond"})
 
   json = t.RenderJson()
-  print json
+  print(json)
   return json
 
 

--- a/samples/gh-23.ask_timeout.py
+++ b/samples/gh-23.ask_timeout.py
@@ -25,7 +25,7 @@ def index (request):
                  ])   
 
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 
@@ -67,7 +67,7 @@ def index_straight_json (request):
 
 }
 """
-    print json
+    print(json)
     return json
 
 

--- a/samples/gh-5.hello_cgi.py
+++ b/samples/gh-5.hello_cgi.py
@@ -16,6 +16,7 @@
 #   3. Place this file in examples folder and chmod it executable
 #   4. Dial up Tropo app, and hear "Hello, World ..."
 
+from __future__ import print_function
 import cgi
 from tropo import Tropo
 
@@ -23,14 +24,14 @@ def hello():
     t = Tropo()
     t.say(['hello world! I am a C G I script.'])
     json = t.RenderJson()
-    print json
+    print(json)
     return json
 
 
 
-print "Content-type: text/json"
-print
-print 
+print("Content-type: text/json")
+print()
+print()
 
 hello()
 

--- a/test/test.py
+++ b/test/test.py
@@ -40,12 +40,12 @@ class TestTropoPython(unittest.TestCase):
                   say = Say("Please enter a 5 digit zip code").json)
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_ask================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_ask=================")
+        print("render json: %s" % pretty_rendered)
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"ask": {"say": {"value": "Please enter a 5 digit zip code"}, "choices": {"value": "[5 digits]"}}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
-        # print "test_ask: %s" % tropo.RenderJson()
+        # print("test_ask: %s" % tropo.RenderJson())
         self.assertEqual(rendered_obj, wanted_obj)
 
     def test_call(self):
@@ -58,13 +58,13 @@ class TestTropoPython(unittest.TestCase):
         tropo.say ("Wish you were here")
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print ("============test_call=============")
-        print "render json: %s" % pretty_rendered
+        print("============test_call=============")
+        print("render json: %s" % pretty_rendered)
 
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"call": {"to": "%s", "network": "SMS", "channel": "TEXT"}}, {"say": {"value": "Wish you were here"}}]}' % self.MY_PHONE
         wanted_obj = jsonlib.loads(wanted_json)
-        # print "test_call: %s" % tropo.RenderJson()
+        # print("test_call: %s" % tropo.RenderJson())
         self.assertEqual(rendered_obj, wanted_obj)
 
     def test_conference(self):
@@ -77,14 +77,14 @@ class TestTropoPython(unittest.TestCase):
                    name="Staff Meeting")
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_conference================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_conference=================")
+        print("render json: %s" % pretty_rendered)
 
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"conference": {"playTones": true, "mute": false, "name": "Staff Meeting", "id": "foo"}}]}'
-        print "wanted_json: %s" % wanted_json
+        print("wanted_json: %s" % wanted_json)
         wanted_obj = jsonlib.loads(wanted_json)
-        # print "test_conference: %s" % tropo.RenderJson()
+        # print("test_conference: %s" % tropo.RenderJson())
         self.assertEqual(rendered_obj, wanted_obj)
 
     def test_hangup(self):
@@ -96,10 +96,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.hangup()
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_hangup================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_hangup=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_hangup: %s" % tropo.RenderJson()
+        # print("test_hangup: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"hangup": {}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -114,10 +114,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.message("Hello World", self.MY_PHONE, channel='TEXT', network='SMS', timeout=5)
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_message================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_message=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_message: %s" % tropo.RenderJson()
+        # print("test_message: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = ' {"tropo": [{"message": {"to": "%s", "say": {"value": "Hello World"}, "network": "SMS", "timeout": 5, "channel": "TEXT"}}]}' % self.MY_PHONE
         wanted_obj = jsonlib.loads(wanted_json)
@@ -135,10 +135,10 @@ class TestTropoPython(unittest.TestCase):
              say="Please hold.")
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_on================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_on=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_on: %s" % tropo.RenderJson()
+        # print("test_on: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = ' {"tropo": [{"on": {"say": {"value": "Please hold."}, "event": "continue", "next": "/weather.py?uri=end"}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -156,10 +156,10 @@ class TestTropoPython(unittest.TestCase):
                      choices=choices_obj)
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_record================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_record=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_record: %s" % tropo.RenderJson()
+        # print("test_record: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = ' {"tropo": [{"record": {"url": "/receive_recording.py", "say": {"value": "Tell us about yourself"}, "choices": {"terminator": "#", "value": ""}}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -174,14 +174,14 @@ class TestTropoPython(unittest.TestCase):
         tropo.redirect(self.MY_PHONE)
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_redirect================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_redirect=================")
+        print("render json: %s" % pretty_rendered)
 
-        print "Wanted_Json %s" % tropo.RenderJson()
+        print("Wanted_Json %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"redirect": {"to": "%s"}}]}' % self.MY_PHONE
         wanted_obj = jsonlib.loads(wanted_json)
-        # print "test_redirect: %s" % tropo.RenderJson()
+        # print("test_redirect: %s" % tropo.RenderJson())
         self.assertEqual(rendered_obj, wanted_obj)
 
     def test_reject(self):
@@ -193,14 +193,14 @@ class TestTropoPython(unittest.TestCase):
         tropo.reject()
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_reject================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_reject=================")
+        print("render json: %s" % pretty_rendered)
 
-        print "Want %s" % tropo.RenderJson()
+        print("Want %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"reject": {}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
-        # print "test_reject: %s" % tropo.RenderJson()
+        # print("test_reject: %s" % tropo.RenderJson())
         self.assertEqual(rendered_obj, wanted_obj)
 
     def test_say(self):
@@ -212,10 +212,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.say("Hello, World")
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_say================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_say=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_say: %s" % tropo.RenderJson()
+        # print("test_say: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"say": {"value": "Hello, World"}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -230,10 +230,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.say(["Hello, World", "How ya doing?"])
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_list_say================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_list_say=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_say: %s" % tropo.RenderJson()
+        # print("test_say: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"say": [{"value": "Hello, World"}, {"value": "How ya doing?"}]}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -248,10 +248,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.startRecording(self.RECORDING_URL)
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_startRecording================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_startRecording=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_startRecording: %s" % tropo.RenderJson()
+        # print("test_startRecording: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"startRecording": {"url": "/receive_recording.py"}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -266,10 +266,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.stopRecording()
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_stopRecording================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_stopRecording=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_stopRecording: %s" % tropo.RenderJson()
+        # print("test_stopRecording: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = ' {"tropo": [{"stopRecording": {}}]}'
         wanted_obj = jsonlib.loads(wanted_json)
@@ -286,10 +286,10 @@ class TestTropoPython(unittest.TestCase):
         tropo.say("Hi. I am a robot")
         rendered = tropo.RenderJson()
         pretty_rendered = tropo.RenderJson(pretty=True)
-        print "===============test_transfer================="
-        print "render json: %s" % pretty_rendered
+        print("===============test_transfer=================")
+        print("render json: %s" % pretty_rendered)
 
-        # print "test_transfer: %s" % tropo.RenderJson()
+        # print("test_transfer: %s" % tropo.RenderJson())
         rendered_obj = jsonlib.loads(rendered)
         wanted_json = '{"tropo": [{"say": {"value": "One moment please."}}, {"transfer": {"to": "6021234567"}}, {"say": {"value": "Hi. I am a robot"}}]}'
         wanted_obj = jsonlib.loads(wanted_json)

--- a/tropo.py
+++ b/tropo.py
@@ -44,6 +44,18 @@ except ImportError:
         except ImportError:
             import json as jsonlib
 
+
+import sys
+
+if sys.version_info < (3,):
+    # In Python 2, we are loosey-goosey with whether we're dealing with
+    # bytestrings or unicode.
+    stringish = basestring
+else:
+    # In Python 3, we require unicode as the deities intended.
+    stringish = str
+
+
 class TropoAction(object):
     """
     Class representing the base Tropo action.
@@ -92,14 +104,14 @@ class Ask(TropoAction):
 
     def __init__(self, choices, **options):
         self._dict = {}
-        if (isinstance(choices, basestring)):
+        if (isinstance(choices, stringish)):
             self._dict['choices'] = Choices(choices).json
         else:
 #            self._dict['choices'] = choices['choices']
             self._dict['choices'] = choices.json
         for opt in self.options_array:
             if opt in options:
-                if ((opt == 'say') and (isinstance(options['say'], basestring))):
+                if ((opt == 'say') and (isinstance(options['say'], stringish))):
                     self._dict['say'] = Say(options['say']).json
                 else:
                     self._dict[opt] = options[opt]
@@ -312,25 +324,25 @@ class On(TropoAction):
         self._dict = {}
         for opt in self.options_array:
             if opt in options:
-                if ((opt == 'say') and (isinstance(options['say'], basestring))):
+                if ((opt == 'say') and (isinstance(options['say'], stringish))):
                     if('voice' in options):
                       self._dict['say'] = Say(options['say'], voice=options['voice']).json
                     else:
                       self._dict['say'] = Say(options['say']).json
              
-                elif ((opt == 'ask') and (isinstance(options['ask'], basestring))):
+                elif ((opt == 'ask') and (isinstance(options['ask'], stringish))):
                   if('voice' in options):
                     self._dict['ask'] = Ask(options['ask'], voice=options['voice']).json
                   else:
                     self._dict['ask'] = Ask(options['ask']).json
               
-                elif ((opt == 'message') and (isinstance(options['message'], basestring))):
+                elif ((opt == 'message') and (isinstance(options['message'], stringish))):
                   if('voice' in options):
                     self._dict['message'] = Message(options['message'], voice=options['voice']).json
                   else:
                     self._dict['message'] = Message(options['message']).json
                 
-                elif ((opt == 'wait') and (isinstance(options['wait'], basestring))):
+                elif ((opt == 'wait') and (isinstance(options['wait'], stringish))):
                   self._dict['wait'] = Wait(options['wait']).json
                   
                 elif(opt != 'voice'):
@@ -375,7 +387,7 @@ class Record(TropoAction):
         self._dict = {'url': url}
         for opt in self.options_array:
             if opt in options:
-                if ((opt == 'say') and (isinstance(options['say'], basestring))):
+                if ((opt == 'say') and (isinstance(options['say'], stringish))):
                     self._dict['say'] = Say(options['say']).json
                 else:
                     self._dict[opt] = options[opt]
@@ -544,7 +556,7 @@ class Transfer(TropoAction):
         if opt in options:
           if opt == "on":
             whisper = []
-            for key, val in options['on'].iteritems():
+            for key, val in options['on'].items():
               newDict = {}
 
               if(key == "ask"):
@@ -683,7 +695,7 @@ class Session(object):
                 setattr(self, "fromaddress", val)
             else:
                 setattr(self, key, val)
-	setattr(self, 'dict', session_dict)
+        setattr(self, 'dict', session_dict)
 
 
 class Tropo(object):
@@ -716,8 +728,8 @@ class Tropo(object):
 # # **Sun May 15 21:21:29 2011** -- egilchri
 
         # Settng the voice in this method call has priority.
-	# Otherwise, we can pick up the voice from the Tropo object,
-	# if it is set there.
+        # Otherwise, we can pick up the voice from the Tropo object,
+        # if it is set there.
         if hasattr (self, 'voice'):
             if (not 'voice' in options):
                 options['voice'] = self.voice
@@ -761,7 +773,7 @@ class Tropo(object):
         Argument: **options is a set of optional keyword arguments.
         See https://www.tropo.com/docs/webapi/message
         """
-        if isinstance(say_obj, basestring):
+        if isinstance(say_obj, stringish):
             say = Say(say_obj).obj
         else:
             say = say_obj
@@ -818,8 +830,8 @@ class Tropo(object):
 # # **Sun May 15 21:21:29 2011** -- egilchri
 
         # Settng the voice in this method call has priority.
-	# Otherwise, we can pick up the voice from the Tropo object,
-	# if it is set there.
+        # Otherwise, we can pick up the voice from the Tropo object,
+        # if it is set there.
         if hasattr (self, 'voice'):
             if (not 'voice' in options):
                 options['voice'] = self.voice
@@ -878,16 +890,17 @@ class Tropo(object):
         return json
 
 if __name__ == '__main__':
-    print """
+    print("""
 
  This is the Python web API for http://www.tropo.com/
 
  To run the test suite, please run:
 
     cd test
-    python test.py
+    python2 test.py
+    python3 test.py
 
 
-"""
+""")
 
 


### PR DESCRIPTION
Code had only a few reasons it wasn't compatible with Python3, and all
of them were bugs.

1) Inconsistent indentation. Sometimes tabs, sometimes spaces. That's a
recipe for trouble and that's why Python3 forbids it.

2) Ambiguity about whether the API values are bytestrings or unicode.
Being unsure is a sin, and Python 3 forces clear thinking here. No
behavior change for Py2, but Py 3 accepts using only unicode, and we
encode at the borders, when fabricating the JSON to send out.

3) print is a function in Python 3, not a statement, so those prints
have to look like function calls. That was surprisingly few changes,
and only one place had non-one arguments.